### PR TITLE
현재위치를 기준으로 가까운위치순으로 게시글 리스트표시

### DIFF
--- a/src/main/java/com/gdsc/blended/post/controller/PostController.java
+++ b/src/main/java/com/gdsc/blended/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.gdsc.blended.post.controller;
 
 import com.gdsc.blended.jwt.oauth.UserInfo;
+import com.gdsc.blended.post.dto.GeoListResponseDto;
 import com.gdsc.blended.post.dto.PostRequestDto;
 import com.gdsc.blended.post.dto.PostResponseDto;
 import com.gdsc.blended.post.service.PostService;
@@ -58,6 +59,16 @@ public class PostController {
 
     }
 
+
+    @GetMapping("/posts/distanceList")
+    public ResponseEntity<List<GeoListResponseDto>> getPostsByDistance(
+            @RequestParam("nowLatitude") Double latitude,
+            @RequestParam("nowLongitude") Double longitude,
+            @RequestParam("distance") Double distance
+    ) {
+        List<GeoListResponseDto> posts = postService.getPostsByDistance(latitude, longitude, distance);
+        return ResponseEntity.status(HttpStatus.OK).body(posts);
+    }
     //TODO .. 찜수 구현
 
     //TODO .. 게

--- a/src/main/java/com/gdsc/blended/post/dto/GeoListResponseDto.java
+++ b/src/main/java/com/gdsc/blended/post/dto/GeoListResponseDto.java
@@ -1,0 +1,33 @@
+package com.gdsc.blended.post.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gdsc.blended.post.entity.PostEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class GeoListResponseDto {
+    @JsonProperty("post_id")
+    private Long id;
+    private String title;
+    private String content;
+    private String locationName;
+    private Double latitude;
+    private Double longitude;
+    private Boolean status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long viewCount;
+    private Long scrapCount;
+    private Long maxRecruits;
+    private Long recruited;
+    private Long category;
+    private double distance;
+    
+
+
+
+}

--- a/src/main/java/com/gdsc/blended/post/dto/PostResponseDto.java
+++ b/src/main/java/com/gdsc/blended/post/dto/PostResponseDto.java
@@ -2,16 +2,17 @@ package com.gdsc.blended.post.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.gdsc.blended.post.entity.PostEntity;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.xml.stream.Location;
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PostResponseDto {
     @JsonProperty("post_id")
     private Long id;
@@ -45,4 +46,6 @@ public class PostResponseDto {
         this.recruited = postEntity.getRecruited();
         this.category = postEntity.getCategory().getId();
     }
+
+
 }

--- a/src/main/java/com/gdsc/blended/post/repository/PostRepository.java
+++ b/src/main/java/com/gdsc/blended/post/repository/PostRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
     @Query("SELECT p FROM PostEntity p ORDER BY p.id DESC")
     List<PostEntity> findAllDesc();
+
 }


### PR DESCRIPTION
## 작업한 내용
- 현재위치를 기준으로 가까운위치순으로 게시글 리스트표시
  DB상에서 정리하는게 아니라 서비스 단에서 위치를 비교해서 느릴수있음 대안을 생각해볼법함

## 이슈
- postgresql에서 확장프로그램이 설치가 안되서 마리아DB로 바꾸었지만 이것 역시 설치해야한다는 문제가 있었음 따라서 서비스단에서 구현하였음

## 백로그 링크

