### PR TITLE
fix: 로그인 닉네임 유무 판단

### DIFF
--- a/src/main/java/com/gdsc/blended/common/message/UserResponseMessage.java
+++ b/src/main/java/com/gdsc/blended/common/message/UserResponseMessage.java
@@ -13,6 +13,7 @@ public enum UserResponseMessage implements ResponseMessage {
     NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공하였습니다.", HttpStatus.OK),
     NICKNAME_UPDATE_FAIL("닉네임 변경 실패", HttpStatus.INTERNAL_SERVER_ERROR),
     NICKNAME_IS_DUPLICATED("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
+    NICKNAME_NOT_PROVIDED("닉네임을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     USER_NOT_FOUND("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     USER_NOT_MATCH("유저에게 권한이 없습니다.", HttpStatus.BAD_REQUEST);
 

--- a/src/main/java/com/gdsc/blended/user/repository/UserRepository.java
+++ b/src/main/java/com/gdsc/blended/user/repository/UserRepository.java
@@ -12,10 +12,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmail(String email);
 
     boolean existsByEmail(String email);
-
     boolean existsByNickname(String newNickname);
 
-    //boolean existsById(String id);
-
-    //boolean findById(String id);
 }

--- a/src/main/java/com/gdsc/blended/user/service/AuthService.java
+++ b/src/main/java/com/gdsc/blended/user/service/AuthService.java
@@ -43,10 +43,17 @@ public class AuthService {
             }
             else {
                 GoogleOAuth2UserInfo userInfo = new GoogleOAuth2UserInfo(googleIdToken.getPayload());
+                String email = userInfo.getEmail();
 
                 if(!userRepository.existsByEmail(userInfo.getEmail())){
                     UserEntity userEntity = new UserEntity(userInfo);
                     userRepository.save(userEntity);
+                }else {
+                    UserEntity user = userRepository.findByEmail(email).orElseThrow(() ->
+                            new ApiException(UserResponseMessage.USER_NOT_FOUND));
+                    if(user.getNickname() == null){
+                        throw new ApiException(UserResponseMessage.NICKNAME_NOT_PROVIDED);
+                    }
                 }
                 return sendGenerateJwtToken(userInfo.getEmail(), userInfo.getName());
             }


### PR DESCRIPTION
## 작업한 내용
1. 사용자가 로그인 버튼을 누르면 클라이언트 측에서 구글 토큰을 생성하고 백엔드로 전송
2. 백엔드는 전달받은 구글 토큰을 검증하고, 토큰에 포함된 정보를 이용하여 유저의 이메일을 확인
3. 이메일을 기준으로 데이터베이스에 해당 이메일을 가진 유저가 있는지 확인
4. 유저가 데이터베이스에 없으면 새로운 유저를 생성하고, 유저가 이미 존재한다면 닉네임이 null인지 확인
5. 닉네임이 null이라면 에러를 반환
6. 닉네임이 null이 아니라면 로그인 성공으로 간주하고 JWT 토큰을 생성하여 반환
로직으로 수정

## 이슈
- 개발하면서 발생한 이슈 적기

## 백로그 링크
- [Blended-180| 로그인 수정] (https://teamblended.atlassian.net/browse/BLDD-180)
